### PR TITLE
Mattermost, UTF8 and folders support

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
@@ -137,8 +137,8 @@ public class CucumberResult {
 		buffer.append("| ------------ | :---------------: | :----------: | :---:  |\n");
 
 		// Iterate over features and build results matrix
-        Integer overallPassed = 0;
-        Integer overallFailed = 0;
+        int overallPassed = 0;
+        int overallFailed = 0;
 
 		for (FeatureResult feature : getFeatureResults()) {
 			buffer.append(String.format("| [%s](%s)", feature.getDisplayName(), hyperLink + feature.getFeatureUri()));

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
@@ -141,7 +141,7 @@ public class CucumberResult {
         int overallFailed = 0;
 
 		for (FeatureResult feature : getFeatureResults()) {
-			buffer.append(String.format("| [%s](%s)", feature.getDisplayName(), hyperLink + feature.getFeatureUri()));
+			buffer.append(String.format("| [%s](%s)", feature.getDisplayName(), hyperLink + feature.getFeatureUri().replace('/', '-')));
 			buffer.append(String.format("| %d%% (%d/%d) ", feature.getPassPercentage(), feature.getTotalPassedScenarios(), feature.getTotalScenarios()));
 			buffer.append(String.format("| %d%% (%d/%d) ", 100 - feature.getPassPercentage(), feature.getTotalFailedScenarios(), feature.getTotalScenarios()));
 			if (feature.getPassPercentage() == 100) {

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
@@ -132,13 +132,14 @@ public class CucumberResult {
 		buffer.append(String.format("Total features: %d\n", this.getFeatureResults().size()));
 		buffer.append(String.format("Total scenarios: %d\n\n", this.totalScenarios));
 
-		buffer.append(String.format("Passed features: %d%%\n\n", getPassPercentage()));
-
 		// Add the top table headers
 		buffer.append("| Features     | Passed            | Failed       | Status |\n");
 		buffer.append("| ------------ | :---------------: | :----------: | :---:  |\n");
 
 		// Iterate over features and build results matrix
+        Integer overallPassed = 0;
+        Integer overallFailed = 0;
+
 		for (FeatureResult feature : getFeatureResults()) {
 			buffer.append(String.format("| [%s](%s)", feature.getDisplayName(), hyperLink + feature.getFeatureUri()));
 			buffer.append(String.format("| %d%% (%d/%d) ", feature.getPassPercentage(), feature.getTotalPassedScenarios(), feature.getTotalScenarios()));
@@ -148,7 +149,18 @@ public class CucumberResult {
 			} else {
 				buffer.append("| :x: |\n");
 			}
+
+			// Update the overall counters
+            overallFailed += feature.getTotalFailedScenarios();
+			overallPassed += feature.getTotalPassedScenarios();
 		}
+
+		// End the table with the overall result
+        buffer.append(String.format(
+                "| *Total*   | *%d%% (%d/%d)*   | *%d%% (%d/%d)*   |  -  |\n",
+                getPassPercentage(), overallPassed, this.totalScenarios,
+                100 - getPassPercentage(), overallFailed, this.totalScenarios
+        ));
 
 		return buffer.toString();
 	}

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
@@ -55,7 +55,7 @@ public class CucumberResult {
 			final int buildNumber, final String channel, final String jenkinsUrl, final String buildUrl) {
 		final JsonObject json = new JsonObject();
 		json.addProperty("channel", "#" + channel);
-		json.addProperty("text", this.buildResultsTable(jobName, buildNumber, buildUrl));
+		json.addProperty("text", this.buildResultsTable(jobName, jenkinsUrl, buildNumber, buildUrl));
 		json.addProperty("username", jobName);
 		return json.toString();
 	}
@@ -115,12 +115,12 @@ public class CucumberResult {
 	}
 
 
-	private String buildResultsTable(final String jobName, final int buildNumber, final String buildUrl) {
-		final String hyperLink = buildUrl + "cucumber-html-reports/report-feature_";
+	private String buildResultsTable(final String jobName, final String jenkinsUrl, final int buildNumber, final String buildUrl) {
+		final String hyperLink = jenkinsUrl + buildUrl + "cucumber-html-reports/report-feature_";
 		StringBuilder buffer = new StringBuilder();
 
 		// Start by writing jobname and build number in message header
-		buffer.append(String.format("#### Test results for job \"%s\", build [#%d](%s) ", jobName, buildNumber, buildUrl));
+		buffer.append(String.format("#### Test results for job \"%s\", build [#%d](%s) ", jobName, buildNumber, jenkinsUrl + buildUrl));
 		if (getPassPercentage() == 100) {
 			buffer.append(":white_check_mark:");
 		} else {

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
@@ -146,6 +146,8 @@ public class CucumberResult {
 			buffer.append(String.format("| %d%% (%d/%d) ", 100 - feature.getPassPercentage(), feature.getTotalFailedScenarios(), feature.getTotalScenarios()));
 			if (feature.getPassPercentage() == 100) {
 				buffer.append("| :white_check_mark: |\n");
+			} else if (feature.getPassPercentage() != 100 && feature.getTotalFailedScenarios() != feature.totalScenarios) {
+				buffer.append("| :warning: |\n");
 			} else {
 				buffer.append("| :x: |\n");
 			}

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlack.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlack.java
@@ -38,7 +38,7 @@ public class CucumberSlack extends JobProperty<Job<?, ?>> {
 
 		@Override
 		public String getDisplayName() {
-			return "Cucumber Slack Notifier";
+			return "Cucumber Slack/Mattermost Notifier";
 		}
 
 		@Override

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlack.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlack.java
@@ -62,7 +62,11 @@ public class CucumberSlack extends JobProperty<Job<?, ?>> {
 			}
 
 			if (!value.startsWith("https://hooks.slack.com/")) {
-				return FormValidation.warning("Slack endpoint should start with https://hooks.slack.com/");
+				if (value.contains("/hooks/")) {
+					return FormValidation.ok("Endpoint assumed to be a Mattermost endpoint, proper message format will be used");
+				} else {
+					return FormValidation.warning("Slack endpoint should start with https://hooks.slack.com/");
+				}
 			}
 
 			return FormValidation.ok();

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlackBuildStepNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlackBuildStepNotifier.java
@@ -90,7 +90,7 @@ public class CucumberSlackBuildStepNotifier extends Builder {
 		}
 
 		public String getDisplayName() {
-			return "Send Cucumber Report to Slack";
+			return "Send Cucumber Report to Slack/Mattermost";
 		}
 
 		@Override

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlackPostBuildNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlackPostBuildNotifier.java
@@ -96,7 +96,7 @@ public class CucumberSlackPostBuildNotifier extends Recorder {
 		}
 
 		public String getDisplayName() {
-			return "Send Cucumber Report to Slack";
+			return "Send Cucumber Report to Slack/Mattermost";
 		}
 
 		@Override

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlackService.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlackService.java
@@ -39,7 +39,7 @@ public class CucumberSlackService {
 		
 		final Gson gson = new Gson();
 		try {
-			final JsonReader jsonReader = new JsonReader(new InputStreamReader(jsonPath.read()));
+			final JsonReader jsonReader = new JsonReader(new InputStreamReader(jsonPath.read(), "UTF-8"));
 			return gson.fromJson(jsonReader, JsonElement.class);
 		} catch (IOException e) {
 			LOG.severe("Exception occurred while reading test results: " + e);

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlackService.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlackService.java
@@ -30,7 +30,7 @@ public class CucumberSlackService {
 
 		JsonElement jsonElement = getResultFileAsJsonElement(workspace, json);
 		SlackClient client = new SlackClient(webhookUrl, jenkinsUrl, channel, hideSuccessfulResults);
-		client.postToSlack(jsonElement, build.getParent().getDisplayName(), build.getNumber(), extra);
+		client.postToSlack(jsonElement, build.getParent().getDisplayName(), build.getNumber(), build.getUrl());
 	}
 
 	private JsonElement getResultFileAsJsonElement(FilePath workspace, String json) {

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/FeatureResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/FeatureResult.java
@@ -3,10 +3,18 @@ package org.jenkinsci.plugins.slacknotifier;
 public class FeatureResult {
 	final String name;
 	final int passPercentage;
+	final int totalFailedScenarios;
+	final int totalScenarios;
 
 	public FeatureResult(String name, int passPercentage) {
+		this(name, passPercentage, 0, 0);
+	}
+
+	public FeatureResult(String name, int passPercentage, int totalScenarios, int totalFailedScenarios) {
 		this.name = name;
 		this.passPercentage = passPercentage;
+		this.totalScenarios = totalScenarios;
+		this.totalFailedScenarios = totalFailedScenarios;
 	}
 
 	public String toString() {
@@ -27,5 +35,17 @@ public class FeatureResult {
 	
 	public int getPassPercentage() {
 		return this.passPercentage;
+	}
+
+	public int getTotalScenarios() {
+		return this.totalScenarios;
+	}
+
+	public int getTotalFailedScenarios() {
+		return this.totalFailedScenarios;
+	}
+
+	public int getTotalPassedScenarios() {
+		return this.totalScenarios - this.totalFailedScenarios;
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/FeatureResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/FeatureResult.java
@@ -5,16 +5,18 @@ public class FeatureResult {
 	final int passPercentage;
 	final int totalFailedScenarios;
 	final int totalScenarios;
+	final String uri;
 
 	public FeatureResult(String name, int passPercentage) {
-		this(name, passPercentage, 0, 0);
+		this(name, passPercentage, 0, 0, name);
 	}
 
-	public FeatureResult(String name, int passPercentage, int totalScenarios, int totalFailedScenarios) {
+	public FeatureResult(String name, int passPercentage, int totalScenarios, int totalFailedScenarios, String uri) {
 		this.name = name;
 		this.passPercentage = passPercentage;
 		this.totalScenarios = totalScenarios;
 		this.totalFailedScenarios = totalFailedScenarios;
+		this.uri = uri;
 	}
 
 	public String toString() {
@@ -24,13 +26,17 @@ public class FeatureResult {
 	public String getName() {
 		return this.name;
 	}
+
+	public String getUri() {
+		return this.uri;
+	}
 	
 	public String getFeatureUri() {
-		return this.name.replace(".feature", "-feature") + ".html";
+		return this.uri.replace(".feature", "-feature") + ".html";
 	}
 	
 	public String getDisplayName() {
-		return this.name.replaceAll("_", " ").replace(".feature", "");
+		return this.name.replaceAll("_", " ").replace(" feature$", "");
 	}
 	
 	public int getPassPercentage() {

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/FeatureResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/FeatureResult.java
@@ -32,7 +32,7 @@ public class FeatureResult {
 	}
 	
 	public String getFeatureUri() {
-		return this.uri.replace(".feature", "-feature") + ".html";
+		return this.uri.replace(".feature", "-feature").replace(" ", "-") + ".html";
 	}
 	
 	public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
@@ -102,7 +102,7 @@ public class SlackClient {
 			totalScenarios = totalScenarios + scenariosTotal;
 			final int scenarioPassPercent = Math.round(((scenariosTotal - failed) * 100) / scenariosTotal);
 			if (scenarioPassPercent != 100 || !hideSuccessfulResults) {
-				results.add(new FeatureResult(feature.get("uri").getAsString(), scenarioPassPercent));
+				results.add(new FeatureResult(feature.get("uri").getAsString(), scenarioPassPercent, scenariosTotal, failed));
 			}
 		}
 		passPercent = Math.round(((totalScenarios - failedScenarios) * 100) / totalScenarios);

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
@@ -34,10 +34,19 @@ public class SlackClient {
 		this.hideSuccessfulResults = hideSuccessfulResults;
 	}
 
-	public void postToSlack(JsonElement results, final String jobName, final int buildNumber, final String extra) {
-		LOG.info("Publishing test report to slack channel: " + channel);
+	public void postToSlack(JsonElement results, final String jobName, final int buildNumber, final String buildUrl) {
+		LOG.info("Publishing test report to channel: " + channel);
 		CucumberResult result = results == null ? dummyResults() : processResults(results);
-		String json = result.toSlackMessage(jobName, buildNumber, channel, jenkinsUrl, extra);
+		String json;
+
+		// If the WebHook URL is similar to Slack, use Slack notifier
+		if (this.webhookUrl.contains("hooks.slack.com")) {
+			LOG.info("Using Slack message format");
+			json = result.toSlackMessage(jobName, buildNumber, channel, jenkinsUrl, buildUrl);
+		} else {
+			LOG.info("Using Mattermost message format");
+			json = result.toMattermostMessage(jobName, buildNumber, channel, jenkinsUrl, buildUrl);
+		}
 		postToSlack(json);
 	}
 

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
@@ -102,7 +102,7 @@ public class SlackClient {
 			totalScenarios = totalScenarios + scenariosTotal;
 			final int scenarioPassPercent = Math.round(((scenariosTotal - failed) * 100) / scenariosTotal);
 			if (scenarioPassPercent != 100 || !hideSuccessfulResults) {
-				results.add(new FeatureResult(feature.get("name").getAsString(), scenarioPassPercent, scenariosTotal, failed));
+				results.add(new FeatureResult(feature.get("name").getAsString(), scenarioPassPercent, scenariosTotal, failed, feature.get("uri").getAsString()));
 			}
 		}
 		passPercent = Math.round(((totalScenarios - failedScenarios) * 100) / totalScenarios);

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
@@ -102,7 +102,7 @@ public class SlackClient {
 			totalScenarios = totalScenarios + scenariosTotal;
 			final int scenarioPassPercent = Math.round(((scenariosTotal - failed) * 100) / scenariosTotal);
 			if (scenarioPassPercent != 100 || !hideSuccessfulResults) {
-				results.add(new FeatureResult(feature.get("uri").getAsString(), scenarioPassPercent, scenariosTotal, failed));
+				results.add(new FeatureResult(feature.get("name").getAsString(), scenarioPassPercent, scenariosTotal, failed));
 			}
 		}
 		passPercent = Math.round(((totalScenarios - failedScenarios) * 100) / totalScenarios);

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,3 @@
 <div>
-  This plugins posts summarised Cucumber report information to Slack
+  This plugins posts summarised Cucumber report information to Slack or Mattermost (based on URL format)
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/slacknotifier/CucumberSlack/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slacknotifier/CucumberSlack/global.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section title="Cucumber Report Slack Notifier">
+  <f:section title="Cucumber Report Slack/Mattermost Notifier">
     <f:entry title="Web Hook Endpoint" field="webHookEndpoint"
       description="This is the url of the webhook endpoint on slack">
       <f:textbox />

--- a/src/main/resources/org/jenkinsci/plugins/slacknotifier/CucumberSlackBuildStepNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slacknotifier/CucumberSlackBuildStepNotifier/config.jelly
@@ -6,7 +6,7 @@
   <f:entry title="JSON Result File" field="json" description="Location of the JSON result file for Cucumber">
     <f:textbox />
   </f:entry>
-  <f:entry title="Hide Successful Results" field="hideSuccessfulResults" description="Only include details of failures in Slack message">
+  <f:entry title="Hide Successful Results" field="hideSuccessfulResults" description="Only include details of failures in Slack/Mattermost message">
     <f:checkbox />
   </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/slacknotifier/CucumberSlackPostBuildNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slacknotifier/CucumberSlackPostBuildNotifier/config.jelly
@@ -6,7 +6,7 @@
   <f:entry title="JSON Result File" field="json" description="Location of the JSON result file for Cucumber">
     <f:textbox />
   </f:entry>
-  <f:entry title="Hide Successful Results" field="hideSuccessfulResults" description="Only include details of failures in Slack message">
+  <f:entry title="Hide Successful Results" field="hideSuccessfulResults" description="Only include details of failures in Slack/Mattermost message">
     <f:checkbox />
   </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/slacknotifier/workflow/CucumberSlackStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slacknotifier/workflow/CucumberSlackStep/config.jelly
@@ -7,7 +7,7 @@
     <f:entry field="json" title="JSON Results File">
         <f:textbox />
     </f:entry>
-    <f:entry title="Hide Successful Results" field="hideSuccessfulResults" description="Only include details of failures in Slack message">
+    <f:entry title="Hide Successful Results" field="hideSuccessfulResults" description="Only include details of failures in Slack/Mattermost message">
         <f:checkbox />
     </f:entry>
     <f:entry field="failOnError">

--- a/src/test/java/org/jenkinsci/plugins/slacknotifier/CucumberResultTest.java
+++ b/src/test/java/org/jenkinsci/plugins/slacknotifier/CucumberResultTest.java
@@ -11,18 +11,8 @@ public class CucumberResultTest {
 	
 	@Test
 	public void canGenerateHeader() {
-		String header = successfulResult().toHeader("test-job", 1, "http://localhost:8080/", null);
+		String header = successfulResult().toHeader("test-job", 1, "http://localhost:8080/", "http://localhost:8080/job/test-job/1/");
 		assertNotNull(header);
-		assertTrue(header.contains("Features: 1"));
-		assertTrue(header.contains("Scenarios: 1"));
-		assertTrue(header.contains("Build: <http://localhost:8080/job/test-job/1/cucumber-html-reports/|1>"));
-	}
-	
-	@Test
-	public void canGenerateHeaderWithExtraInformation() {
-		String header = successfulResult().toHeader("test-job", 1, "http://localhost:8080/", "Extra Content");
-		assertNotNull(header);
-		assertTrue(header.contains("Extra Content"));
 		assertTrue(header.contains("Features: 1"));
 		assertTrue(header.contains("Scenarios: 1"));
 		assertTrue(header.contains("Build: <http://localhost:8080/job/test-job/1/cucumber-html-reports/|1>"));

--- a/src/test/java/org/jenkinsci/plugins/slacknotifier/SlackClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/slacknotifier/SlackClientTest.java
@@ -30,9 +30,9 @@ public class SlackClientTest {
 		assertEquals(8, result.getTotalFeatures());
 		assertEquals(100, result.getPassPercentage());
 		
-		String slackMessage = result.toSlackMessage("test-job", 7, "channel", "http://jenkins:8080/", null);
+		String slackMessage = result.toSlackMessage("test-job", 7, "channel", "http://jenkins:8080/", "http://jenkins:8080/job/test-job/7/");
 		assertNotNull(slackMessage);
-		assertTrue(slackMessage.contains("<http://jenkins:8080/job/test-job/7/cucumber-html-reports/validate_gerrit_home_page-feature.html|validate gerrit home page>"));
+		assertTrue(slackMessage.contains("<http://jenkins:8080/job/test-job/7/cucumber-html-reports/validate_gerrit_home_page-feature.html|Validate Gerrit Home Page>"));
 	}
 
 	@Test
@@ -46,7 +46,7 @@ public class SlackClientTest {
 		assertEquals(0, result.getTotalFeatures());
 		assertEquals(100, result.getPassPercentage());
 
-		String slackMessage = result.toSlackMessage("test-job", 7, "channel", "http://jenkins:8080/", null);
+		String slackMessage = result.toSlackMessage("test-job", 7, "channel", "http://jenkins:8080/", "http://jenkins:8080/job/test-job/7/");
 		assertNotNull(slackMessage);
 	}
 	
@@ -76,21 +76,21 @@ public class SlackClientTest {
 	
 	@Test
 	public void canGenerateGoodMessage() {
-		String slackMessage = successfulResult().toSlackMessage("test-job", 1, "channel", "http://jenkins:8080/", null);
+		String slackMessage = successfulResult().toSlackMessage("test-job", 1, "channel", "http://jenkins:8080/", "http://jenkins:8080/job/test-job/1/");
 		assertNotNull(slackMessage);
 		assertTrue(slackMessage.contains("good"));
 	}
 
 	@Test
 	public void canGenerateMarginalMessage() {
-		String slackMessage = marginalResult().toSlackMessage("test-job", 1, "channel", "http://jenkins:8080/", null);
+		String slackMessage = marginalResult().toSlackMessage("test-job", 1, "channel", "http://jenkins:8080/", "http://jenkins:8080/job/test-job/1/");
 		assertNotNull(slackMessage);
 		assertTrue(slackMessage.contains("warning"));
 	}
 
 	@Test
 	public void canGenerateBadMessage() {
-		String slackMessage = badResult().toSlackMessage("test-job", 1, "channel", "http://jenkins:8080/", null);
+		String slackMessage = badResult().toSlackMessage("test-job", 1, "channel", "http://jenkins:8080/", "http://jenkins:8080/job/test-job/1/");
 		assertNotNull(slackMessage);
 		assertTrue(slackMessage.contains("danger"));
 	}


### PR DESCRIPTION
These commits add the following improvements:

- Mattermost notification support (based on URL)
- Extended tabular report with a feature-level detail (for Mattermost only, since Mattermost Markdown support is better)
- UTF8 input files support
- Support for jobs in subfolders

Example of Mattermost notification can be found below:

<img width="423" alt="mattermost_notification" src="https://user-images.githubusercontent.com/8759452/48940107-c815f000-ef16-11e8-957b-d59e16d74157.png">
