### PR TITLE
MultiChannel support + fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ The following options are available:
 
 TODO: add a screen shot here 
 
-### Build Configuration
+* Channel Webhook URL - slack channel Webhook URL to post result to
+* JSON Result File - json file containing the cucumber results, e.g. target/cucumber.json
 
-* channel - slack channel to post result to
-* json - json file containing the cucumber results, e.g. target/cucumber.json
-
-TODO: add a screen shot here 
+![config](https://i.ibb.co/sj6X6T8/Screenshot-from-2019-04-23-14-46-47.png)

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>cucumber-slack-notifier</artifactId>
-    <version>0.8.4-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Cucumber+Slack+Notifier+Plugin</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.609.2</version>
+        <version>2.13</version>
         <relativePath/>
     </parent>
 

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.slacknotifier;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.apache.commons.lang.StringUtils;
@@ -95,11 +96,8 @@ public class CucumberResult {
         json.addProperty("text", toHeader(jobName, buildNumber, jenkinsUrl, extra));
     }
 
-    private void addAttachmentColor(JsonArray json, String colorValue) {
-        JsonPrimitive colorPropertyValue = new JsonPrimitive(colorValue);
-        JsonObject colorProperty = new JsonObject();
-        colorProperty.add("color", colorPropertyValue);
-        json.add(colorProperty);
+    private void addAttachmentColor(JsonArray jsonArray, String colorValue) {
+        jsonArray.get(0).getAsJsonObject().addProperty("color", colorValue);
     }
 
     private JsonArray getFields(final String jobName, final int buildNumber, final String jenkinsUrl) {

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
@@ -105,10 +105,12 @@ public class CucumberResult {
         final JsonArray fields = new JsonArray();
         fields.add(shortTitle("Features"));
         fields.add(shortTitle("Pass %"));
+        int counter = 0;
         for (FeatureResult feature : getFeatureResults()) {
+            counter++;
             final String featureDisplayName = feature.getDisplayName();
-            final String featureFileName = feature.getFeatureUri();
-            fields.add(shortObject("<" + hyperLink + featureFileName + "|" + featureDisplayName + ">"));
+            final String featureFileUri = feature.getUri();
+            fields.add(shortObject("<" + hyperLink + "report-feature_" + counter + "_" + toValidFileName(featureFileUri) + ".html|" + featureDisplayName + ">"));
             fields.add(shortObject(feature.getPassPercentage() + " %"));
         }
         fields.add(shortObject("-------------------------------"));
@@ -132,4 +134,16 @@ public class CucumberResult {
         obj.addProperty("short", true);
         return obj;
     }
+
+    /**
+     * Converts characters of passed string and replaces to hash which can be treated as valid file name
+     *
+     * @param fileName sequence that should be converted
+     * @return converted string
+     */
+    private String toValidFileName(String fileName) {
+        // adds MAX_VALUE to eliminate minus character which might be returned by hashCode()
+        return Long.toString((long) fileName.hashCode() + Integer.MAX_VALUE);
+    }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
@@ -34,10 +34,9 @@ public class CucumberResult {
         return this.featureResults;
     }
 
-    public String toSlackMessage(final String jobName,
-                                 final int buildNumber, final String channel, final String jenkinsUrl, final String extra) {
+    public String toSlackMessage(final String jobName, final int buildNumber, final String jenkinsUrl, final String extra) {
         final JsonObject json = new JsonObject();
-        json.addProperty("channel", "#" + channel);
+        json.addProperty("channel", "#");
         addCaption(json, buildNumber, jobName, jenkinsUrl, extra);
 
         final JsonArray attachmentsJson = new JsonArray();

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberResult.java
@@ -1,9 +1,7 @@
 package org.jenkinsci.plugins.slacknotifier;
 
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.List;
@@ -105,14 +103,7 @@ public class CucumberResult {
         final JsonArray fields = new JsonArray();
         fields.add(shortTitle("Features"));
         fields.add(shortTitle("Pass %"));
-        int counter = 0;
-        for (FeatureResult feature : getFeatureResults()) {
-            counter++;
-            final String featureDisplayName = feature.getDisplayName();
-            final String featureFileUri = feature.getUri();
-            fields.add(shortObject("<" + hyperLink + "report-feature_" + counter + "_" + toValidFileName(featureFileUri) + ".html|" + featureDisplayName + ">"));
-            fields.add(shortObject(feature.getPassPercentage() + " %"));
-        }
+        generateFeaturesFields(fields, hyperLink);
         fields.add(shortObject("-------------------------------"));
         fields.add(shortObject("-------"));
         fields.add(shortObject("Total Passed"));
@@ -120,6 +111,22 @@ public class CucumberResult {
         return fields;
     }
 
+    private void generateFeaturesFields(JsonArray fields, String hyperLink){
+        int counter = 0;
+        for (FeatureResult feature : getFeatureResults()) {
+            final String featureDisplayName = feature.getDisplayName();
+            final String featureFileUri = feature.getUri();
+
+            if (counter == 0){
+                fields.add(shortObject("<" + hyperLink + "report-feature_" + toValidFileName(featureFileUri) + ".html|" + featureDisplayName + ">"));
+            }else{
+                fields.add(shortObject("<" + hyperLink + "report-feature_" + counter + "_" + toValidFileName(featureFileUri) + ".html|" + featureDisplayName + ">"));
+            }
+
+            fields.add(shortObject(feature.getPassPercentage() + " %"));
+            counter++;
+        }
+    }
 
     private JsonObject shortObject(final String value) {
         JsonObject obj = new JsonObject();

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlackService.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/CucumberSlackService.java
@@ -14,21 +14,18 @@ import java.util.logging.Logger;
 public class CucumberSlackService {
 
     private static final Logger LOG = Logger.getLogger(CucumberSlackService.class.getName());
-
-    private final String webhookUrl;
     private final String jenkinsUrl;
 
     public CucumberSlackService(String webhookUrl) {
-        this.webhookUrl = webhookUrl;
         this.jenkinsUrl = JenkinsLocationConfiguration.get().getUrl();
     }
 
-    public void sendCucumberReportToSlack(Run<?, ?> build, FilePath workspace, String json, String channel, String extra, boolean hideSuccessfulResults) {
+    public void sendCucumberReportToSlack(Run<?, ?> build, FilePath workspace, String json, String channelWebhookUrl, String extra, boolean hideSuccessfulResults) {
         LOG.info("Posting cucumber reports to slack for '" + build.getParent().getDisplayName() + "'");
         LOG.info("Cucumber reports are in '" + workspace + "'");
 
         JsonElement jsonElement = getResultFileAsJsonElement(workspace, json);
-        SlackClient client = new SlackClient(webhookUrl, jenkinsUrl, channel, hideSuccessfulResults);
+        SlackClient client = new SlackClient(jenkinsUrl, channelWebhookUrl, hideSuccessfulResults);
         client.postToSlack(jsonElement, build.getParent().getDisplayName(), build.getNumber(), extra);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/FeatureResult.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/FeatureResult.java
@@ -19,10 +19,6 @@ public class FeatureResult {
         return this.uri;
     }
 
-    public String getFeatureUri() {
-        return this.uri.replaceAll("/", "-").replace(".feature", "-feature") + ".html";
-    }
-
     public String getDisplayName() {
         return this.name;
     }

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
@@ -21,22 +21,20 @@ public class SlackClient {
     private static final String ENCODING = "UTF-8";
     private static final String CONTENT_TYPE = "application/json";
 
-    private final String webhookUrl;
     private final String jenkinsUrl;
-    private final String channel;
+    private final String channelWebhookUrl;
     private final boolean hideSuccessfulResults;
 
-    public SlackClient(String webhookUrl, String jenkinsUrl, String channel, boolean hideSuccessfulResults) {
-        this.webhookUrl = webhookUrl;
+    public SlackClient(String jenkinsUrl, String channelWebhookUrl, boolean hideSuccessfulResults) {
         this.jenkinsUrl = jenkinsUrl;
-        this.channel = channel;
+        this.channelWebhookUrl = channelWebhookUrl;
         this.hideSuccessfulResults = hideSuccessfulResults;
     }
 
     public void postToSlack(JsonElement results, final String jobName, final int buildNumber, final String extra) {
-        LOG.info("Publishing test report to slack channel: " + channel);
+        LOG.info("Publishing test report to slack channelWebhookUrl: " + channelWebhookUrl);
         CucumberResult result = results == null ? dummyResults() : processResults(results);
-        String json = result.toSlackMessage(jobName, buildNumber, channel, jenkinsUrl, extra);
+        String json = result.toSlackMessage(jobName, buildNumber, jenkinsUrl, extra);
         postToSlack(json);
     }
 
@@ -48,7 +46,7 @@ public class SlackClient {
     private void postToSlack(String json) {
         LOG.fine("Json being posted: " + json);
         StringRequestEntity requestEntity = getStringRequestEntity(json);
-        PostMethod postMethod = new PostMethod(webhookUrl);
+        PostMethod postMethod = new PostMethod(channelWebhookUrl);
         postMethod.setRequestEntity(requestEntity);
         postToSlack(postMethod);
     }

--- a/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
+++ b/src/main/java/org/jenkinsci/plugins/slacknotifier/SlackClient.java
@@ -72,11 +72,14 @@ public class SlackClient {
         for (JsonElement featureElement : features) {
             JsonObject feature = featureElement.getAsJsonObject();
             JsonArray elements = feature.get("elements").getAsJsonArray();
-            int scenariosTotal = elements.size();
+            int scenariosTotal = 0;
             int failed = 0;
             for (JsonElement scenarioElement : elements) {
                 JsonObject scenario = scenarioElement.getAsJsonObject();
                 JsonArray steps = scenario.get("steps").getAsJsonArray();
+                if (scenario.get("type").getAsString().equalsIgnoreCase("scenario")){
+                    scenariosTotal = scenariosTotal + 1;
+                }
                 for (JsonElement stepElement : steps) {
                     JsonObject step = stepElement.getAsJsonObject();
                     String result = step.get("result").getAsJsonObject().get("status").getAsString();

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugins posts summarised Cucumber report information to Slack
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/slacknotifier/CucumberSlackBuildStepNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slacknotifier/CucumberSlackBuildStepNotifier/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="Channel" field="channel" description="Which slack channel to post to ...">
+  <f:entry title="Channel Webhook URL" field="channel" description="Which slack channel to post to ...">
     <f:textbox />
   </f:entry>
   <f:entry title="JSON Result File" field="json" description="Location of the JSON result file for Cucumber">

--- a/src/main/resources/org/jenkinsci/plugins/slacknotifier/CucumberSlackPostBuildNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slacknotifier/CucumberSlackPostBuildNotifier/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="Channel" field="channel" description="Which slack channel to post to ...">
+  <f:entry title="Channel Webhook URL" field="channel" description="Which slack channel to post to ...">
     <f:textbox />
   </f:entry>
   <f:entry title="JSON Result File" field="json" description="Location of the JSON result file for Cucumber">

--- a/src/main/resources/org/jenkinsci/plugins/slacknotifier/workflow/CucumberSlackStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/slacknotifier/workflow/CucumberSlackStep/config.jelly
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry field="channel" title="Channel">
+    <f:entry field="channel" title="Channel Webhook URL">
         <f:textbox />
     </f:entry>
     <f:entry field="json" title="JSON Results File">

--- a/src/test/java/org/jenkinsci/plugins/slacknotifier/SlackClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/slacknotifier/SlackClientTest.java
@@ -25,7 +25,8 @@ public class SlackClientTest {
 
         String slackMessage = result.toSlackMessage("test-job", 7, "http://jenkins:8080/", null);
         assertNotNull(slackMessage);
-        assertTrue(slackMessage.contains("<http://jenkins:8080/job/test-job/7/cucumber-html-reports/report-feature_2_552978313.html|Validate Gerrit Home Page>"));
+        assertTrue(slackMessage.contains("<http://jenkins:8080/job/test-job/7/cucumber-html-reports/report-feature_751168504.html|Validate Confluence Home Page>"));
+        assertTrue(slackMessage.contains("<http://jenkins:8080/job/test-job/7/cucumber-html-reports/report-feature_1_552978313.html|Validate Gerrit Home Page>"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/slacknotifier/SlackClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/slacknotifier/SlackClientTest.java
@@ -16,14 +16,14 @@ public class SlackClientTest {
     public void canGenerateFullSuccessfulSlackMessage() throws FileNotFoundException {
         JsonElement element = loadTestResultFile("successful-result.json");
         assertNotNull(element);
-        CucumberResult result = new SlackClient("http://slack.com/", "http://jenkins:8080/", "channel", false).processResults(element);
+        CucumberResult result = new SlackClient("http://jenkins:8080/", "http://slack.com/", false).processResults(element);
         assertNotNull(result);
         assertNotNull(result.getFeatureResults());
         assertEquals(8, result.getTotalScenarios());
         assertEquals(8, result.getTotalFeatures());
         assertEquals(100, result.getPassPercentage());
 
-        String slackMessage = result.toSlackMessage("test-job", 7, "channel", "http://jenkins:8080/", null);
+        String slackMessage = result.toSlackMessage("test-job", 7, "http://jenkins:8080/", null);
         assertNotNull(slackMessage);
         assertTrue(slackMessage.contains("<http://jenkins:8080/job/test-job/7/cucumber-html-reports/validate_gerrit_home_page-feature.html|Validate Gerrit Home Page>"));
     }
@@ -32,14 +32,14 @@ public class SlackClientTest {
     public void canGenerateMinimalSuccessfulSlackMessage() throws FileNotFoundException {
         JsonElement element = loadTestResultFile("successful-result.json");
         assertNotNull(element);
-        CucumberResult result = new SlackClient("http://slack.com/", "http://jenkins:8080/", "channel", true).processResults(element);
+        CucumberResult result = new SlackClient("http://jenkins:8080/", "http://slack.com/", true).processResults(element);
         assertNotNull(result);
         assertNotNull(result.getFeatureResults());
         assertEquals(8, result.getTotalScenarios());
         assertEquals(0, result.getTotalFeatures());
         assertEquals(100, result.getPassPercentage());
 
-        String slackMessage = result.toSlackMessage("test-job", 7, "channel", "http://jenkins:8080/", null);
+        String slackMessage = result.toSlackMessage("test-job", 7, "http://jenkins:8080/", null);
         assertNotNull(slackMessage);
     }
 
@@ -47,7 +47,7 @@ public class SlackClientTest {
     public void canGenerateFullFailedSlackMessage() throws FileNotFoundException {
         JsonElement element = loadTestResultFile("failed-result.json");
         assertNotNull(element);
-        CucumberResult result = new SlackClient("http://slack.com/", "http://jenkins:8080/", "channel", false).processResults(element);
+        CucumberResult result = new SlackClient("http://jenkins:8080/", "http://slack.com/", false).processResults(element);
         assertNotNull(result);
         assertNotNull(result.getFeatureResults());
         assertEquals(8, result.getTotalScenarios());
@@ -59,7 +59,7 @@ public class SlackClientTest {
     public void canGenerateMinimalFailedSlackMessage() throws FileNotFoundException {
         JsonElement element = loadTestResultFile("failed-result.json");
         assertNotNull(element);
-        CucumberResult result = new SlackClient("http://slack.com/", "http://jenkins:8080/", "channel", true).processResults(element);
+        CucumberResult result = new SlackClient("http://jenkins:8080/", "http://slack.com/", true).processResults(element);
         assertNotNull(result);
         assertNotNull(result.getFeatureResults());
         assertEquals(8, result.getTotalScenarios());
@@ -69,21 +69,21 @@ public class SlackClientTest {
 
     @Test
     public void canGenerateGoodMessage() {
-        String slackMessage = successfulResult().toSlackMessage("test-job", 1, "channel", "http://jenkins:8080/", null);
+        String slackMessage = successfulResult().toSlackMessage("test-job", 1, "http://jenkins:8080/", null);
         assertNotNull(slackMessage);
         assertTrue(slackMessage.contains("good"));
     }
 
     @Test
     public void canGenerateMarginalMessage() {
-        String slackMessage = marginalResult().toSlackMessage("test-job", 1, "channel", "http://jenkins:8080/", null);
+        String slackMessage = marginalResult().toSlackMessage("test-job", 1, "http://jenkins:8080/", null);
         assertNotNull(slackMessage);
         assertTrue(slackMessage.contains("warning"));
     }
 
     @Test
     public void canGenerateBadMessage() {
-        String slackMessage = badResult().toSlackMessage("test-job", 1, "channel", "http://jenkins:8080/", null);
+        String slackMessage = badResult().toSlackMessage("test-job", 1, "http://jenkins:8080/", null);
         assertNotNull(slackMessage);
         assertTrue(slackMessage.contains("danger"));
     }

--- a/src/test/java/org/jenkinsci/plugins/slacknotifier/SlackClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/slacknotifier/SlackClientTest.java
@@ -25,7 +25,7 @@ public class SlackClientTest {
 
         String slackMessage = result.toSlackMessage("test-job", 7, "http://jenkins:8080/", null);
         assertNotNull(slackMessage);
-        assertTrue(slackMessage.contains("<http://jenkins:8080/job/test-job/7/cucumber-html-reports/validate_gerrit_home_page-feature.html|Validate Gerrit Home Page>"));
+        assertTrue(slackMessage.contains("<http://jenkins:8080/job/test-job/7/cucumber-html-reports/report-feature_2_552978313.html|Validate Gerrit Home Page>"));
     }
 
     @Test
@@ -102,14 +102,14 @@ public class SlackClientTest {
     }
 
     private CucumberResult successfulResult() {
-        return new CucumberResult(Collections.singletonList(new FeatureResult("Dummy Test","Dummy Test", 100)), 1, 100);
+        return new CucumberResult(Collections.singletonList(new FeatureResult("Dummy Uri","Dummy Feature", 100)), 1, 100);
     }
 
     private CucumberResult badResult() {
-        return new CucumberResult(Collections.singletonList(new FeatureResult("Dummy Test","Dummy Test", 0)), 1, 0);
+        return new CucumberResult(Collections.singletonList(new FeatureResult("Dummy Uri","Dummy Feature", 0)), 1, 0);
     }
 
     private CucumberResult marginalResult() {
-        return new CucumberResult(Collections.singletonList(new FeatureResult("Dummy Test","Dummy Test", 99)), 1, 99);
+        return new CucumberResult(Collections.singletonList(new FeatureResult("Dummy Uri","Dummy Feature", 99)), 1, 99);
     }
 }


### PR DESCRIPTION
Changes on this request:
- 'Channel' property changed to 'Channel Webhook URL' so now each Jenkins job can send the notifications to a different channel (a single slack webhook can't be used for multiple channels)
- parent jenkins pom updated to v2.13 ac9d7fc
- fix slack msg links to feature files (the cucumber-reports-plugin changed the way generates url links) 45a034f ad69d80
- fix cucumber Background operation was being as an extra scenario giving wrong scenarios count on slack msg 243b681
- fix slack msg color (was being added as JsonObject instead of property of current array) a49ae70

Please let me know if any further clarification is required